### PR TITLE
Allow $OPAMROOT be something else than $HOME/.opam

### DIFF
--- a/nfsopam.sh
+++ b/nfsopam.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/env bash
 
 # make opam usable (faster) even if your $OPAMROOT is on top of NFS
 # by using /tmp (usually a local disk) for most operations

--- a/nfsopam.sh
+++ b/nfsopam.sh
@@ -1,4 +1,4 @@
-#! /bin/env bash
+#! /usr/bin/env bash
 
 # make opam usable (faster) even if your $OPAMROOT is on top of NFS
 # by using /tmp (usually a local disk) for most operations

--- a/nfsopam.sh
+++ b/nfsopam.sh
@@ -8,7 +8,7 @@ set -x # debug
 # sync ~/.opam to local disk
 opam clean
 tmp_dot_opam=/tmp/${USER}_dot_opam
-rsync -q ~/.opam/* $tmp_dot_opam
+rsync -qa ~/.opam/ $tmp_dot_opam
 mv -f ~/.opam ~/.opam.old
 
 # use it
@@ -21,4 +21,4 @@ opam "$@"
 opam clean
 \rm ~/.opam
 mv ~/.opam.old ~/.opam
-rsync -q $tmp_dot_opam/* ~/.opam
+rsync -qa $tmp_dot_opam/ ~/.opam

--- a/nfsopam.sh
+++ b/nfsopam.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
 
-# make opam usable (faster) even if your $HOME is on top of NFS
+# make opam usable (faster) even if your $OPAMROOT is on top of NFS
 # by using /tmp (usually a local disk) for most operations
 
 set -x # debug
 
-# sync ~/.opam to local disk
+# determine the $OPAMROOT
+for i in $(seq $#); do
+    case ${!i} in
+	--root=*)
+	    OPAMROOT=${!i#*=};;
+	--root)
+	    (( i += 1 ))
+	    OPAMROOT=${!i};;
+    esac
+done
+OPAMROOT=${OPAMROOT:-$HOME/.opam}
+
+# sync $OPAMROOT to local disk
 opam clean
 tmp_dot_opam=/tmp/${USER}_dot_opam
-rsync -qa ~/.opam/ $tmp_dot_opam
-mv -f ~/.opam ~/.opam.old
+rsync -qa $OPAMROOT/ $tmp_dot_opam
+mv -f $OPAMROOT $OPAMROOT.old
 
 # use it
-ln -s $tmp_dot_opam ~/.opam
+ln -s $tmp_dot_opam $OPAMROOT
 
 # really call opam
 opam "$@"
 
 # sync back to home on NFS
 opam clean
-\rm ~/.opam
-mv ~/.opam.old ~/.opam
-rsync -qa $tmp_dot_opam/ ~/.opam
+\rm $OPAMROOT
+mv $OPAMROOT.old $OPAMROOT
+rsync -qa $tmp_dot_opam/ $OPAMROOT


### PR DESCRIPTION
There are 3 minor changes here.

$OPAMROOT is allowed to be something else than $HOME/.opam.

The --archive switch is added to rsync to make sure that the $OPAM_SWITCH_PREFIX/.opam-switch is copied.

The bash path is determined from the environment.